### PR TITLE
[IT-4225] Clarify image version

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,22 +19,22 @@ repo in the `templates/ImageBuilder` directory.
 
 Next step is to use the definition template to provision an AMI:
 1. In this repo, add a new Sceptre config in `config/prod` directory referencing
-a versioned (or tagged) instance of the cloudformation template.  Set the
-the `ImageVersion` to the same number as the aws-infra repo tag (i.e. 0.9.2 without the `v`).
-It must match a [semantic version](https://semver.org/) number.
+a versioned (or tagged) instance of the cloudformation template.  The `ImageVersion`
+is arbitrary however it must follow the [semantic version](https://semver.org/)
+convention (i.e. X.Y.Z). We typically start with `1.0.0` and increment as needed.
 2. Create a PR to merge the new config into the `main` branch.
 3. Once the PR is merged, the cloudformation template will be deployed to the
 AWS org-sagebase-imagecentral account which will in turn trigger a build
 of the image which will generate an AMI.
-4. The AMI will be shared to all accounts in our AWS organization which
-means that it is searchable from any of our AWS accounts using either the
+4. The AMI will be publicly shared to __ALL__ AWS accounts which
+means that it is searchable from any AWS accounts using either the
 AWS console EC2 Instances->AMIs or Image Builder->Images pages. The AMI is
 also searchable using the AWS CLI
 [describe-images command](https://docs.aws.amazon.com/cli/latest/reference/ec2/describe-images.html).
 
 
 ### Updating Images
-To update an image the we must first update aws-infra then this repo.
+To update an image we must first update aws-infra then this repo.
 
 Update the cloudformation template in aws-infra:
 1. Create a PR to update the ImageBuilder cloudformation template in the aws-infra repo
@@ -42,17 +42,14 @@ Update the cloudformation template in aws-infra:
 3. Tag the repo with a version number
 
 Update the Sceptre config in this repo:
-1. Create a PR to update the template `url` reference and `ImageVersion` number
-in the Sceptre config file.
+1. Create a PR to update the template `url` reference
+2. Increment the `ImageVersion` number in the Sceptre config file otherwise
+cloudformation may fail with a message similar to `The following resource XXXXX already exists..`.
 2. Review, approve and Merge the PR
 3. Once merged the cloudformation template will be deployed which will trigger
 an update to the AMI.  AMIs are immutable therefore AWS will create a new AMI
 on every change.  The updated AMIs will retain the same name, only the version
 number is updated.
-
-__Note__: An update to the image definition (or cloudformation template) requires
-an `ImageVersion` update otherwise cloudformation may fail with a message similar to
-`The following resource XXXXX already exists..`.
 
 ### Removing Images
 Important info when removing image builder resources and the generated

--- a/config/prod/agora-data-manager-github-runner.yaml
+++ b/config/prod/agora-data-manager-github-runner.yaml
@@ -6,5 +6,4 @@ stack_tags:
   OwnerEmail: "jessica.britton@sagebase.org"
   CostCenter: "Agora / 112300"
 parameters:
-  ImageVersion: "0.9.4"
-  VolumeSize: "50"
+  ImageVersion: "1.0.0"


### PR DESCRIPTION
There are cases where you may want to update the ImageVersion number without needing to update the underlying template.  For example, when you want to update a passed in parameter but keep the template the same.  In those situation the ImageVersion still needs to be incremented.  The convention of setting the ImageVersion number to the aws-infra template does not work for that use case.  Update the convention to just use an arbitrary version number.

Also start over with agora-data-manager-github-runner image

