### PR TITLE
SAGL-72: Update image builder pipeline to use v. 0.9.9 of aws-infra

### DIFF
--- a/config/prod/cis-for-beanstalk-image-pipeline.yaml
+++ b/config/prod/cis-for-beanstalk-image-pipeline.yaml
@@ -1,9 +1,9 @@
 template:
   type: "http"
-  url: "https://raw.githubusercontent.com/Sage-Bionetworks/aws-infra/v0.9.8/templates/ImageBuilder/cis-for-eb-image-pipeline-template.yaml"
+  url: "https://raw.githubusercontent.com/Sage-Bionetworks/aws-infra/v0.9.9/templates/ImageBuilder/cis-for-eb-image-pipeline-template.yaml"
 stack_name: "cis-for-beanstalk-image-pipeline"
 stack_tags:
   OwnerEmail: "it@sagebase.org"
   CostCenter: "Platform Infrastructure / 990300"
 parameters:
-  ImageVersion: "1.0.0"
+  ImageVersion: "1.0.1"


### PR DESCRIPTION
Update image builder pipeline to use v. 0.9.9 of aws-infra