### PR TITLE
IT-4697: Update CIS image pipeline to use template from aws-infra v0.10.5

### DIFF
--- a/config/prod/agora-data-manager-github-runner.yaml
+++ b/config/prod/agora-data-manager-github-runner.yaml
@@ -4,6 +4,6 @@ template:
 stack_name: "agora-data-manager-github-runner"
 stack_tags:
   OwnerEmail: "jessica.britton@sagebase.org"
-  CostCenter: "AMP-AD DCC / 101500"
+  CostCenter: "AMP-AD DCC Renewal / 101500"
 parameters:
   ImageVersion: "1.0.0"

--- a/config/prod/cis-for-beanstalk-image-pipeline.yaml
+++ b/config/prod/cis-for-beanstalk-image-pipeline.yaml
@@ -1,6 +1,6 @@
 template:
   type: "http"
-  url: "https://raw.githubusercontent.com/Sage-Bionetworks/aws-infra/v0.10.2/templates/ImageBuilder/cis-for-eb-image-pipeline-template.yaml"
+  url: "https://raw.githubusercontent.com/Sage-Bionetworks/aws-infra/v0.10.5/templates/ImageBuilder/cis-for-eb-image-pipeline-template.yaml"
 stack_name: "cis-for-beanstalk-image-pipeline"
 stack_tags:
   OwnerEmail: "it@sagebase.org"


### PR DESCRIPTION
IT-4697: Update CIS image pipeline to use template from aws-infra v0.10.5

Depends on Sage-Bionetworks/aws-infra#438