### PR TITLE
[IT-4417] Deploy new image pipeline

### DIFF
--- a/config/prod/amazon-linux-2023-docker-image-pipeline.yaml
+++ b/config/prod/amazon-linux-2023-docker-image-pipeline.yaml
@@ -1,0 +1,9 @@
+template:
+  type: "http"
+  url: "https://raw.githubusercontent.com/Sage-Bionetworks/aws-infra/v0.10.7/templates/ImageBuilder/amazon-linux-2023-docker.yaml"
+stack_name: "amazon-linux-2023-docker-image-pipeline"
+stack_tags:
+  OwnerEmail: "it@sagebase.org"
+  CostCenter: "Platform Infrastructure / 990300"
+parameters:
+  ImageVersion: "1.0.0"


### PR DESCRIPTION
Create a new ImageBuilder pipeline for our Amazon Linux 2023 AMIs used by our EC2 products in Service Catalog.